### PR TITLE
refs #1449

### DIFF
--- a/Model/Behavior/M17nBehavior.php
+++ b/Model/Behavior/M17nBehavior.php
@@ -175,30 +175,22 @@ class M17nBehavior extends ModelBehavior {
  * @SuppressWarnings(PHPMD.NPathComplexity)
  */
 	public function beforeSave(Model $model, $options = array()) {
-$this->log($model->alias . ' ' . __LINE__, 'debug');
-if ($model->alias == 'CategoriesLanguage') {
-$this->log($model->data, 'debug');
-}
 		if (! $this->_hasM17nFields($model)) {
 			return true;
 		}
-$this->log($model->alias . ' ' . __LINE__, 'debug');
 
 		$keyField = $this->settings[$model->name]['keyField'];
 		if (! $keyField) {
 			return true;
 		}
-$this->log($model->alias . ' ' . __LINE__, 'debug');
 
 		if (! $this->isM17nGeneralPlugin($model)) {
 			return true;
 		}
-$this->log($model->alias . ' ' . __LINE__, 'debug');
 
 		if ($model->hasField('is_original_copy')) {
 			$model->data[$model->alias]['is_original_copy'] = false;
 		}
-$this->log($model->alias . ' ' . __LINE__, 'debug');
 
 		//チェックするためのWHERE条件
 		if ($this->_hasWorkflowFields($model)) {
@@ -212,7 +204,6 @@ $this->log($model->alias . ' ' . __LINE__, 'debug');
 				'language_id' => Current::read('Language.id'),
 				'is_latest' => true
 			);
-$this->log($model->alias . ' ' . __LINE__, 'debug');
 		} else {
 			$transConditions = array(
 				$keyField => $model->data[$model->alias][$keyField],
@@ -222,7 +213,6 @@ $this->log($model->alias . ' ' . __LINE__, 'debug');
 				$keyField => $model->data[$model->alias][$keyField],
 				'language_id' => Current::read('Language.id')
 			);
-$this->log($model->alias . ' ' . __LINE__, 'debug');
 		}
 
 		//データが1件もないことを確認する
@@ -233,10 +223,6 @@ $this->log($model->alias . ' ' . __LINE__, 'debug');
 				$keyField => $model->data[$model->alias][$keyField]
 			),
 		));
-$this->log($model->alias . ' ' . __LINE__, 'debug');
-if ($model->alias == 'CategoriesLanguage') {
-$this->log($model->data, 'debug');
-}
 		if ($count <= 0) {
 			$model->data[$model->alias]['language_id'] = Current::read('Language.id');
 			$model->data[$model->alias]['is_origin'] = true;
@@ -244,7 +230,6 @@ $this->log($model->data, 'debug');
 
 			return true;
 		}
-$this->log($model->alias . ' ' . __LINE__, 'debug');
 
 		$model->data[$model->alias]['language_id'] = Current::read('Language.id');
 
@@ -259,7 +244,6 @@ $this->log($model->alias . ' ' . __LINE__, 'debug');
 		} else {
 			$model->data[$model->alias]['is_translation'] = false;
 		}
-$this->log($model->alias . ' ' . __LINE__, 'debug');
 
 		//当言語のデータのチェック
 		$data = $model->find('first', array(
@@ -275,12 +259,6 @@ $this->log($model->alias . ' ' . __LINE__, 'debug');
 			$model->data[$model->alias] = Hash::remove($model->data[$model->alias], 'id');
 			$model->id = null;
 		}
-$this->log($model->alias . ' ' . __LINE__, 'debug');
-if ($model->alias == 'CategoriesLanguage') {
-$this->log($model->data, 'debug');
-}
-
-
 		return parent::beforeSave($model, $options);
 	}
 

--- a/Model/Behavior/M17nBehavior.php
+++ b/Model/Behavior/M17nBehavior.php
@@ -157,8 +157,7 @@ class M17nBehavior extends ModelBehavior {
 		if (Current::read('Plugin.type') !== Plugin::PLUGIN_TYPE_FOR_FRAME) {
 			return true;
 		}
-		if (! Current::read('Room.id') || ! Current::read('Plugin.is_m17n') ||
-				! Current::read('Space.is_m17n')) {
+		if (! Current::read('Room.id') || ! Current::read('Plugin.is_m17n')) {
 			return false;
 		}
 
@@ -176,22 +175,30 @@ class M17nBehavior extends ModelBehavior {
  * @SuppressWarnings(PHPMD.NPathComplexity)
  */
 	public function beforeSave(Model $model, $options = array()) {
+$this->log($model->alias . ' ' . __LINE__, 'debug');
+if ($model->alias == 'CategoriesLanguage') {
+$this->log($model->data, 'debug');
+}
 		if (! $this->_hasM17nFields($model)) {
 			return true;
 		}
+$this->log($model->alias . ' ' . __LINE__, 'debug');
 
 		$keyField = $this->settings[$model->name]['keyField'];
 		if (! $keyField) {
 			return true;
 		}
+$this->log($model->alias . ' ' . __LINE__, 'debug');
 
 		if (! $this->isM17nGeneralPlugin($model)) {
 			return true;
 		}
+$this->log($model->alias . ' ' . __LINE__, 'debug');
 
 		if ($model->hasField('is_original_copy')) {
 			$model->data[$model->alias]['is_original_copy'] = false;
 		}
+$this->log($model->alias . ' ' . __LINE__, 'debug');
 
 		//チェックするためのWHERE条件
 		if ($this->_hasWorkflowFields($model)) {
@@ -205,6 +212,7 @@ class M17nBehavior extends ModelBehavior {
 				'language_id' => Current::read('Language.id'),
 				'is_latest' => true
 			);
+$this->log($model->alias . ' ' . __LINE__, 'debug');
 		} else {
 			$transConditions = array(
 				$keyField => $model->data[$model->alias][$keyField],
@@ -214,6 +222,7 @@ class M17nBehavior extends ModelBehavior {
 				$keyField => $model->data[$model->alias][$keyField],
 				'language_id' => Current::read('Language.id')
 			);
+$this->log($model->alias . ' ' . __LINE__, 'debug');
 		}
 
 		//データが1件もないことを確認する
@@ -224,6 +233,10 @@ class M17nBehavior extends ModelBehavior {
 				$keyField => $model->data[$model->alias][$keyField]
 			),
 		));
+$this->log($model->alias . ' ' . __LINE__, 'debug');
+if ($model->alias == 'CategoriesLanguage') {
+$this->log($model->data, 'debug');
+}
 		if ($count <= 0) {
 			$model->data[$model->alias]['language_id'] = Current::read('Language.id');
 			$model->data[$model->alias]['is_origin'] = true;
@@ -231,6 +244,7 @@ class M17nBehavior extends ModelBehavior {
 
 			return true;
 		}
+$this->log($model->alias . ' ' . __LINE__, 'debug');
 
 		$model->data[$model->alias]['language_id'] = Current::read('Language.id');
 
@@ -245,6 +259,7 @@ class M17nBehavior extends ModelBehavior {
 		} else {
 			$model->data[$model->alias]['is_translation'] = false;
 		}
+$this->log($model->alias . ' ' . __LINE__, 'debug');
 
 		//当言語のデータのチェック
 		$data = $model->find('first', array(
@@ -260,6 +275,11 @@ class M17nBehavior extends ModelBehavior {
 			$model->data[$model->alias] = Hash::remove($model->data[$model->alias], 'id');
 			$model->id = null;
 		}
+$this->log($model->alias . ' ' . __LINE__, 'debug');
+if ($model->alias == 'CategoriesLanguage') {
+$this->log($model->data, 'debug');
+}
+
 
 		return parent::beforeSave($model, $options);
 	}


### PR DESCRIPTION
language_idを設定しなくていい、とfalseを返すのはRoom.idがない時と、Plugin自体がm17nに対応していない時だけにすべき
Spaceの設定がどうであれ、プラグインとしてm17nが動作することを期待しているならば、language_idを設定してあげないと
language_idが空欄になってしまって、現在のlanguage_idに対応するデータを取り出せなくなるのではないか